### PR TITLE
Konfiguracija pisav

### DIFF
--- a/fontconfig.r
+++ b/fontconfig.r
@@ -1,0 +1,19 @@
+# Pred uporabo namestite paket extrafont, potem pa izvedite
+#   library(extrafont)
+#   font_import() # vpraša za potrditev, traja nekaj minut
+#   loadfonts()
+# Slednja ukaza izvedite samo enkrat in ju ne vključujte v program!
+
+library(extrafont)
+
+# Prosim, da uporabljate eno od sledečih vrednosti za parameter family:
+# * "Arial"
+# * "Arial Black"
+# * "Comic Sans MS"
+# * "Courier New"
+# * "Georgia"
+# * "Impact"
+# * "Trebuchet MS"
+# * "Times New Roman"
+# * "Verdana"
+pdf.options(family = "Arial")


### PR DESCRIPTION
V datoteki `zadnjih50.csv` imaš namesto znaka `à` v imenu `Fàbregas` vprašaj. Odpri to datoteko v RStudiu, potem pa v meniju _File_ klikni na _Reopen with Encoding..._ in izberi **WINDOWS-1252**. Potem lahko vprašaj nadomestiš z `à` in datoteko shraniš.

Da se bo ta znak pravilno izpisal v grafih, sprejmi tale pull request, potem pa sledi navodilom v programu `fontconfig.r` - tega tudi vključi v glavni program med `clearpdf.r` in `uvoz.r`. Za datoteke, kjer se pojavlja ta znak (lahko pa tudi kar povsod), bo treba ukaze `pdf` nadomestiti s `cairo_pdf`, pri čemer bo potrebno vsakič podati tudi izbrano pisavo, npr.

``` R
cairo_pdf("slike/najboljsi.pdf", family = "Arial")
```

Če bi želel risati več grafov v isti PDF, bo potrebno dodati še parameter `onefile = TRUE`.
